### PR TITLE
Add support for dates in the future 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ An easy-to-use and lightweight **Angular Pipe**, that transform any DateLike Inp
 
 ## Overview
 
-- [x] Supports all common inputs that represent a DateTime including:
+- [x] Display both, **past and future** events well readable
+- [x] Support for all common type of input values that represent some sort of DateTime including:
+  * Basically everything that can be parsed by JavaScripts Date Constructor
   * Numeric Epoch time values like (**Unix Timestamp** or JavaScripts Date.now())
   * **ISO (8601) Strings** (Example `2021-01-31T03:58:23.658Z`)
-  * Basically everything that can be parsed by JavaScripts Date Constructor
-- [x] Fallback for invalid inputs
 - [x] Light-weight, performance optimized and easy to use
+- [x] [Customizable and Translatable](#customization)
+- [x] No stale timestamp...
 
 ### Demo
 
@@ -23,22 +25,40 @@ See it in Action and try it by yourself on the [Demo Playground](https://ng-time
 
 ### Outputs
 
-From Top to Bottom (First Fit)
+From top to bottom (First Fit)
 
-| Time Input           | Output             |Extra
-| -------------------- | ------------------ |---
-| Below 5 seconds      | a few seconds ago  | -
-| Below 59 seconds     | X seconds ago      | Updates every second
-| Below 90 seconds     | about a minute ago | -
-| Below 45 Minutes     | X minutes ago      | Updates every minute
-| Below 90 Minutes     | an hour ago        | -
-| Below 22 Hours       | X hours ago        | Updates every hour
-| Below 36 Hours       | a day ago          | -
-| Below 25 Days        | X days ago         | -
-| Below 45 Days        | a month ago        | -
-| Below 356 Days       | X months ago       | -
-| Below 545 Days       | a year ago         | -
-| More than 546 Days   | X years ago        | -
+#### Times in the past
+
+| Time Input         | Output             | Extra                |
+|--------------------|--------------------|----------------------|
+| Below 5 seconds    | a few seconds ago  | Updates every second |
+| Below 59 seconds   | X seconds ago      | -                    |
+| Below 90 seconds   | about a minute ago | -                    |
+| Below 45 Minutes   | X minutes ago      | Updates every minute |
+| Below 90 Minutes   | one hour ago       | -                    |
+| Below 22 Hours     | X hours ago        | Updates every hour   |
+| Below 36 Hours     | a day ago          | -                    |
+| Below 25 Days      | X days ago         | -                    |
+| Below 45 Days      | a month ago        | -                    |
+| Below 356 Days     | X months ago       | -                    |
+| Below 545 Days     | a year ago         | -                    |
+| More than 546 Days | X years ago        | -                    |
+
+#### Times in the future
+
+| Time Input         | Output        | Extra                 |
+|--------------------|---------------|-----------------------|
+| Below 59 Seconds   | in X seconds  | Updates every second  |
+| Below 90 Seconds   | in one minute | -                     |
+| Below 59 Minutes   | in X minutes  | Updates every minute  |
+| Below 90 Minutes   | in one hour   | -                     |
+| Below 22 Hours     | in X hours    | Updates every hour    |
+| Below 36 Hours     | in one day    | -                     |
+| Below 25 Days      | in X days     | -                     |
+| Below 45 Days      | in one month  | -                     |
+| Below 356 Days     | in X months   | -                     |
+| Below 545 Days     | in one year   | -                     |
+| More than 546 Days | in X years    | -                     |
 
 
 ## Installation
@@ -107,11 +127,12 @@ import {
 
 export const timeDiffGenerator: TimeDiffGenerator = (diff): string => {
   if (diff.seconds <= 5) {
-    return 'This very Moment';
+    return diff.isFuture ? 'In a few moments' : 'A few moments ago';
   } else {
     return defaultTimeDiffGenerator(diff);
   }
 }
+
 
 @NgModule({
   declarations: [TestComponent],
@@ -124,6 +145,7 @@ export const timeDiffGenerator: TimeDiffGenerator = (diff): string => {
 export class TestModule {}
 ```
 
+Distinguish between future and past events by `diff.isFuture`.
 You can always fall back to the `defaultTimeDiffGenerator` your custom one, as shown in the example above.
 
 ### Adjust the Update Interval
@@ -133,7 +155,7 @@ When you make changes to the "Result Output", you should keep in mind that the d
 Default Update Interval:
 
 | Time Difference    | Update Interval  |
-| ------------------ | ---------------- |
+|--------------------|------------------|
 | less than 1 min    | every second     |
 | less than an hour  | every 30 seconds |
 | less then a day    | every 5 minutes  |
@@ -168,7 +190,7 @@ Keep in mind that the return value should be the interval in **seconds**.
 ## Notes
 
 This is a rewrite of the orphaned project [AndrewPoyntz Time-ago-pipe](https://github.com/AndrewPoyntz/time-ago-pipe).
-It's a hard fork and should provide a better performance and compatibility.
+It's a hard fork and should provide a better performance and compatibility as well as additional features.
 
 Feel free to open an issue when you are missing any feature or experience any problems.
 Any contributions are welcome :)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,8 @@ module.exports = function (config) {
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+      captureConsole: true,
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, './coverage/Playground'),

--- a/projects/ng-time-past-pipe/src/lib/ticker.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/ticker.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { TIME_PAST_TICKER } from './ticker';
+import { InjectionToken } from '@angular/core';
+import { interval, Observable } from 'rxjs';
+
+describe('TIME_PAST_TICKER', () => {
+  const TEST_SERVICE_1 = new InjectionToken('TestService1');
+  const TEST_SERVICE_2 = new InjectionToken('TestService2');
+  const tickerFactory = (ticker) => ({ ticker });
+
+  describe('Instance', () => {
+    let tickerInstance: Observable<number>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: TEST_SERVICE_1,
+            useFactory: tickerFactory,
+            deps: [TIME_PAST_TICKER],
+          },
+          {
+            provide: TEST_SERVICE_2,
+            useFactory: tickerFactory,
+            deps: [TIME_PAST_TICKER],
+          },
+        ],
+      });
+
+      tickerInstance = TestBed.inject(TIME_PAST_TICKER);
+    });
+
+    it('should always return the same object', () => {
+      expect((TestBed.inject(TEST_SERVICE_1) as { ticker }).ticker).toBe(
+        tickerInstance
+      );
+      expect((TestBed.inject(TEST_SERVICE_2) as { ticker }).ticker).toBe(
+        tickerInstance
+      );
+    });
+  });
+});

--- a/projects/ng-time-past-pipe/src/lib/time-diff.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-diff.spec.ts
@@ -1,15 +1,591 @@
-describe('createTimeDiff', () => {
+import {
+  createTimeDiff,
+  defaultTimeDiffGenerator,
+  getFutureDiffString,
+  getPastDiffString,
+  TimeDiff,
+} from './time-diff';
 
+const zeroInput = {
+  seconds: 0,
+  minutes: 0,
+  hours: 0,
+  days: 0,
+  months: 0,
+  years: 0,
+  isFuture: true,
+};
+
+describe('createTimeDiff', () => {
+  const values: Array<[number, TimeDiff]> = [
+    [
+      1,
+      {
+        isFuture: false,
+        years: 0,
+        months: 0,
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 1,
+      },
+    ],
+    [
+      500,
+      {
+        isFuture: false,
+        years: 0,
+        months: 0,
+        days: 0,
+        hours: 0,
+        minutes: 8,
+        seconds: 500,
+      },
+    ],
+    [
+      1000,
+      {
+        isFuture: false,
+        years: 0,
+        months: 0,
+        days: 0,
+        hours: 0,
+        minutes: 17,
+        seconds: 1000,
+      },
+    ],
+    [
+      50000,
+      {
+        isFuture: false,
+        years: 0,
+        months: 0,
+        days: 1,
+        hours: 14,
+        minutes: 833,
+        seconds: 50000,
+      },
+    ],
+    [
+      100000,
+      {
+        isFuture: false,
+        years: 0,
+        months: 0,
+        days: 1,
+        hours: 28,
+        minutes: 1667,
+        seconds: 100000,
+      },
+    ],
+    [
+      5000000,
+      {
+        isFuture: false,
+        years: 0,
+        months: 2,
+        days: 58,
+        hours: 1389,
+        minutes: 83333,
+        seconds: 5000000,
+      },
+    ],
+    [
+      15000000,
+      {
+        isFuture: false,
+        years: 0,
+        months: 6,
+        days: 174,
+        hours: 4167,
+        minutes: 250000,
+        seconds: 15000000,
+      },
+    ],
+    [
+      55000000,
+      {
+        isFuture: false,
+        years: 2,
+        months: 21,
+        days: 637,
+        hours: 15278,
+        minutes: 916667,
+        seconds: 55000000,
+      },
+    ],
+    [
+      Number.MAX_SAFE_INTEGER,
+      {
+        isFuture: false,
+        years: 285616415,
+        months: 3427472099,
+        days: 104249991374,
+        hours: 2501999792984,
+        minutes: 150119987579017,
+        seconds: Number.MAX_SAFE_INTEGER,
+      },
+    ],
+  ];
+
+  describe('correct output for dates in the past', () => {
+    values.forEach(([input, output]) => {
+      it(`parse the positive value ${input} as the correct diff object`, () => {
+        expect(createTimeDiff(input)).toEqual(output);
+      });
+    });
+  });
+
+  describe('correct output for dates in the future', () => {
+    values.forEach(([input, output]) => {
+      const inputFuture = input * -1;
+      const outputFuture = { ...output, isFuture: true };
+
+      it(`parse the negative value ${inputFuture} as the correct diff object`, () => {
+        expect(createTimeDiff(inputFuture)).toEqual(outputFuture);
+      });
+    });
+  });
 });
 
 describe('getPastDiffString', () => {
+  const values: Array<[Partial<TimeDiff>, string]> = [
+    [
+      {
+        seconds: 3,
+      },
+      'a few seconds ago',
+    ],
+    [
+      {
+        seconds: 6,
+      },
+      '6 seconds ago',
+    ],
+    [
+      {
+        seconds: 59,
+      },
+      '59 seconds ago',
+    ],
+    [
+      {
+        seconds: 60,
+        minutes: 1,
+      },
+      'about a minute ago',
+    ],
+    [
+      {
+        seconds: 89,
+        minutes: 1,
+      },
+      'about a minute ago',
+    ],
+    [
+      {
+        seconds: 91,
+        minutes: 2,
+      },
+      '2 minutes ago',
+    ],
+    [
+      {
+        seconds: 2700,
+        minutes: 45,
+        hours: 1,
+      },
+      '45 minutes ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 46,
+        hours: 1,
+      },
+      'one hour ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 90,
+        hours: 1,
+      },
+      'one hour ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 2,
+      },
+      '2 hours ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 22,
+      },
+      '22 hours ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 23,
+        days: 1,
+      },
+      'a day ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 36,
+        days: 1,
+      },
+      'a day ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 2,
+      },
+      '2 days ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 25,
+      },
+      '25 days ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 26,
+        months: 1,
+      },
+      'a month ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 45,
+        months: 1,
+      },
+      'a month ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 345,
+        months: 11,
+        years: 1,
+      },
+      '11 months ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 346,
+        months: 12,
+        years: 1,
+      },
+      'a year ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 545,
+        months: 18,
+        years: 1,
+      },
+      'a year ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 546,
+        months: 19,
+        years: 1,
+      },
+      '1 years ago',
+    ],
+    [
+      {
+        seconds: 2701,
+        minutes: 91,
+        hours: 37,
+        days: 546,
+        months: 19,
+        years: 12,
+      },
+      '12 years ago',
+    ],
+  ];
 
+  values.forEach(([originalInput, output]) => {
+    const input = {
+      ...zeroInput,
+      ...originalInput,
+      isFuture: false,
+    };
+
+    it(`returns ${output} as the correct string`, () => {
+      expect(getPastDiffString(input)).toEqual(output);
+    });
+  });
 });
 
 describe('getFutureDiff', () => {
+  const values: Array<[Partial<TimeDiff>, string]> = [
+    [
+      {
+        seconds: 1,
+      },
+      'in 1 seconds',
+    ],
+    [
+      {
+        seconds: 12,
+      },
+      'in 12 seconds',
+    ],
+    [
+      {
+        seconds: 59,
+      },
+      'in 59 seconds',
+    ],
+    [
+      {
+        seconds: 60,
+        minutes: 1,
+      },
+      'in one minute',
+    ],
+    [
+      {
+        seconds: 89,
+        minutes: 1,
+      },
+      'in one minute',
+    ],
+    [
+      {
+        seconds: 91,
+        minutes: 2,
+      },
+      'in 2 minutes',
+    ],
+    [
+      {
+        seconds: 3540,
+        minutes: 59,
+      },
+      'in 59 minutes',
+    ],
+    [
+      {
+        seconds: 3600,
+        minutes: 60,
+        hours: 1,
+      },
+      'in one hour',
+    ],
+    [
+      {
+        seconds: 5280,
+        minutes: 88,
+        hours: 1,
+      },
+      'in one hour',
+    ],
+    [
+      {
+        seconds: 5401,
+        minutes: 91,
+        hours: 2,
+      },
+      'in 2 hours',
+    ],
+    [
+      {
+        seconds: 79200,
+        minutes: 1320,
+        hours: 22,
+      },
+      'in 22 hours',
+    ],
+    [
+      {
+        seconds: 86400,
+        minutes: 1440,
+        hours: 24,
+        days: 1,
+      },
+      'in one day',
+    ],
+    [
+      {
+        seconds: 126000,
+        minutes: 2100,
+        hours: 35,
+        days: 1,
+      },
+      'in one day',
+    ],
+    [
+      {
+        seconds: 126001,
+        minutes: 2101,
+        hours: 37,
+        days: 2,
+      },
+      'in 2 days',
+    ],
+    [
+      {
+        seconds: 2160000,
+        minutes: 36000,
+        hours: 600,
+        days: 25,
+      },
+      'in 25 days',
+    ],
+    [
+      {
+        seconds: 2160001,
+        minutes: 36001,
+        hours: 601,
+        days: 37,
+        months: 1,
+      },
+      'in one month',
+    ],
+    [
+      {
+        seconds: 3801600,
+        minutes: 63360,
+        hours: 1056,
+        days: 44,
+        months: 1,
+      },
+      'in one month',
+    ],
+    [
+      {
+        seconds: 3888001,
+        minutes: 64801,
+        hours: 1081,
+        days: 46,
+        months: 2,
+      },
+      'in 2 months',
+    ],
+    [
+      {
+        seconds: 21081600,
+        minutes: 351360,
+        hours: 5856,
+        days: 244,
+        months: 8,
+      },
+      'in 8 months',
+    ],
+    [
+      {
+        seconds: 29808000,
+        minutes: 496800,
+        hours: 8280,
+        days: 345,
+        months: 12,
+      },
+      'in 12 months',
+    ],
+    [
+      {
+        seconds: 29808001,
+        minutes: 496801,
+        hours: 8281,
+        days: 346,
+        months: 13,
+        years: 1,
+      },
+      'in one year',
+    ],
+    [
+      {
+        seconds: 47088000,
+        minutes: 784800,
+        hours: 1308,
+        days: 545,
+        months: 18,
+        years: 1,
+      },
+      'in one year',
+    ],
+    [
+      {
+        seconds: 47088001,
+        minutes: 784801,
+        hours: 1307,
+        days: 546,
+        months: 19,
+        years: 2,
+      },
+      'in 2 years',
+    ],
+    [
+      {
+        seconds: 378432000,
+        minutes: 6307200,
+        hours: 105120,
+        days: 4380,
+        months: 144,
+        years: 12,
+      },
+      'in 12 years',
+    ],
+  ];
 
+  values.forEach(([originalInput, output]) => {
+    const input = {
+      ...zeroInput,
+      ...originalInput,
+    };
+
+    it(`returns ${output} as the correct string`, () => {
+      expect(getFutureDiffString(input)).toEqual(output);
+    });
+  });
 });
 
 describe('defaultTimeDiffGenerator', () => {
+  const expectedOutput = 'about now';
 
+  it('returns correct string for zero input (isFuture)', () => {
+    expect(defaultTimeDiffGenerator(zeroInput)).toEqual(expectedOutput);
+    expect(defaultTimeDiffGenerator({ ...zeroInput, isFuture: false })).toEqual(
+      expectedOutput
+    );
+  });
 });

--- a/projects/ng-time-past-pipe/src/lib/time-diff.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-diff.spec.ts
@@ -1,0 +1,15 @@
+describe('createTimeDiff', () => {
+
+});
+
+describe('getPastDiffString', () => {
+
+});
+
+describe('getFutureDiff', () => {
+
+});
+
+describe('defaultTimeDiffGenerator', () => {
+
+});

--- a/projects/ng-time-past-pipe/src/lib/time-diff.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-diff.ts
@@ -13,6 +13,7 @@ export interface TimeDiff {
   months: number;
   days: number;
   years: number;
+  isFuture?: boolean;
 }
 
 /**
@@ -29,7 +30,9 @@ export type TimeDiffGenerator = (diff: TimeDiff) => string;
  * @public
  * @api
  */
-export const CUSTOM_TIME_DIFF_GENERATOR = new InjectionToken<TimeDiffGenerator>('Custom Time Diff Generator');
+export const CUSTOM_TIME_DIFF_GENERATOR = new InjectionToken<TimeDiffGenerator>(
+  'Custom Time Diff Generator'
+);
 
 /**
  * Return a respective textual representation of the input, as the input is a timespan that has been passed.
@@ -38,12 +41,18 @@ export const CUSTOM_TIME_DIFF_GENERATOR = new InjectionToken<TimeDiffGenerator>(
  * @public
  * @api
  */
-export const defaultTimeDiffGenerator: TimeDiffGenerator = (diff: TimeDiff): string => {
-  const { seconds, minutes, hours, months, days, years } = diff;
-
-  if (seconds < 0) {
+export const defaultTimeDiffGenerator: TimeDiffGenerator = (
+  diff: TimeDiff
+): string => {
+  if (diff.seconds === 0) {
     return 'about now';
   }
+
+  return diff.isFuture ? getFutureDiffString(diff) : getPastDiffString(diff);
+};
+
+export const getPastDiffString = (diff: TimeDiff) => {
+  const { seconds, minutes, hours, months, days, years } = diff;
 
   if (seconds <= 5) {
     return 'a few seconds ago';
@@ -56,7 +65,7 @@ export const defaultTimeDiffGenerator: TimeDiffGenerator = (diff: TimeDiff): str
   if (minutes <= 45) {
     return minutes + ' minutes ago';
   } else if (minutes <= 90) {
-    return 'an hour ago';
+    return 'one hour ago';
   }
 
   if (hours <= 22) {
@@ -80,32 +89,82 @@ export const defaultTimeDiffGenerator: TimeDiffGenerator = (diff: TimeDiff): str
   return years + ' years ago';
 };
 
+export const getFutureDiffString = (diff: TimeDiff): string => {
+  const { seconds, minutes, hours, months, days, years } = diff;
+
+  if (seconds <= 59) {
+    return 'in ' + seconds + ' seconds';
+  }
+
+  if (seconds <= 90) {
+    return 'in one minute';
+  } else if (minutes <= 59) {
+    return 'in ' + minutes + ' minutes';
+  }
+
+  if (minutes <= 90) {
+    return 'in one hour';
+  } else if (hours <= 22) {
+    return 'in ' + hours + ' hours';
+  }
+
+  if (hours <= 36) {
+    return 'in one day';
+  } else if (days <= 25) {
+    return 'in ' + days + ' days';
+  }
+
+  if (days <= 45) {
+    return 'in one month';
+  } else if (days <= 345) {
+    return 'in ' + months + ' months';
+  }
+
+  if (days <= 545) {
+    return 'in one year';
+  }
+
+  return 'in ' + years + ' years';
+};
+
 /**
  * Provides the TimeDiffGenerator preferring a custom provider for internal usage
  *
  * @internal
  */
-export const TIME_DIFF_GENERATOR = new InjectionToken<TimeDiffGenerator>('Time Diff Generator', {
-  factory: () => {
-    const customGenerator = inject(CUSTOM_TIME_DIFF_GENERATOR, InjectFlags.Optional);
-    return customGenerator ?? defaultTimeDiffGenerator;
-  },
-});
+export const TIME_DIFF_GENERATOR = new InjectionToken<TimeDiffGenerator>(
+  'Time Diff Generator',
+  {
+    factory: () => {
+      const customGenerator = inject(
+        CUSTOM_TIME_DIFF_GENERATOR,
+        InjectFlags.Optional
+      );
+      return customGenerator ?? defaultTimeDiffGenerator;
+    },
+  }
+);
 
 /**
  * TimeDiff Factory
  *
- * @param seconds The time difference in seconds
+ * @param seconds The time difference in seconds. Negative values are considered as a future event
  * @internal
  */
 export const createTimeDiff = (seconds: number): TimeDiff => {
-  const diff: Partial<TimeDiff> = { seconds };
+  const isFuture = seconds < 0;
 
-  diff.minutes = Math.round(Math.abs(seconds / 60));
-  diff.hours = Math.round(Math.abs(diff.minutes / 60));
-  diff.days = Math.round(Math.abs(diff.hours / 24));
-  diff.months = Math.round(Math.abs(diff.days / 30.416));
-  diff.years = Math.round(Math.abs(diff.days / 365));
+  if (isFuture) {
+    seconds = Math.abs(seconds);
+  }
+
+  const diff: Partial<TimeDiff> = { seconds, isFuture };
+
+  diff.minutes = Math.round(seconds / 60);
+  diff.hours = Math.round(diff.minutes / 60);
+  diff.days = Math.round(diff.hours / 24);
+  diff.months = Math.round(diff.days / 30.416);
+  diff.years = Math.round(diff.days / 365);
 
   return diff as TimeDiff;
 };

--- a/projects/ng-time-past-pipe/src/lib/time-interval.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-interval.spec.ts
@@ -1,0 +1,156 @@
+import {
+  CUSTOM_UPDATE_INTERVAL_GENERATOR,
+  defaultUpdateIntervalGenerator,
+  UPDATE_INTERVAL_GENERATOR,
+} from './time-interval';
+import { TestBed } from '@angular/core/testing';
+import { TimeDiff } from './time-diff';
+import { InjectionToken } from '@angular/core';
+
+const zeroTimeDiff: TimeDiff = {
+  seconds: 0,
+  minutes: 0,
+  hours: 0,
+  days: 0,
+  months: 0,
+  years: 0,
+  isFuture: false,
+};
+
+describe('defaultUpdateIntervalGenerator', () => {
+  it('should return the predefined interval', () => {
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 0 })
+    ).toEqual(1);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 1 })
+    ).toEqual(1);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 59 })
+    ).toEqual(1);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 61 })
+    ).toEqual(30);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 2000 })
+    ).toEqual(30);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 3599 })
+    ).toEqual(30);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 3600 })
+    ).toEqual(300);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 3601 })
+    ).toEqual(300);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 44000 })
+    ).toEqual(300);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 86399 })
+    ).toEqual(300);
+    expect(
+      defaultUpdateIntervalGenerator({ ...zeroTimeDiff, seconds: 86401 })
+    ).toEqual(3600);
+    expect(
+      defaultUpdateIntervalGenerator({
+        ...zeroTimeDiff,
+        seconds: Number.MAX_SAFE_INTEGER,
+      })
+    ).toEqual(3600);
+  });
+});
+
+describe('UPDATE_INTERVAL_GENERATOR & CUSTOM_UPDATE_INTERVAL_GENERATOR', () => {
+  const TEST_SERVICE_1 = new InjectionToken('TestService1');
+  const TEST_SERVICE_2 = new InjectionToken('TestService2');
+  const updateIntervalGeneratorFactory = (generator) => ({ generator });
+
+  describe('Instance Default', () => {
+    let updateIntervalGeneratorInstance: (diff: TimeDiff) => number;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: TEST_SERVICE_1,
+            useFactory: updateIntervalGeneratorFactory,
+            deps: [UPDATE_INTERVAL_GENERATOR],
+          },
+          {
+            provide: TEST_SERVICE_2,
+            useFactory: updateIntervalGeneratorFactory,
+            deps: [UPDATE_INTERVAL_GENERATOR],
+          },
+        ],
+      });
+
+      updateIntervalGeneratorInstance = TestBed.inject(
+        UPDATE_INTERVAL_GENERATOR
+      );
+    });
+
+    it('should always return the same object', () => {
+      expect((TestBed.inject(TEST_SERVICE_1) as { generator }).generator).toBe(
+        updateIntervalGeneratorInstance
+      );
+      expect((TestBed.inject(TEST_SERVICE_2) as { generator }).generator).toBe(
+        updateIntervalGeneratorInstance
+      );
+    });
+  });
+
+  describe('Instance Override', () => {
+    let updateIntervalGeneratorInstance: (diff: TimeDiff) => number;
+    const spyInstance = jasmine
+      .createSpy('customUpdateIntervalGeneratorMock')
+      .and.callFake(() => 0);
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: CUSTOM_UPDATE_INTERVAL_GENERATOR,
+            useValue: spyInstance,
+          },
+          {
+            provide: TEST_SERVICE_1,
+            useFactory: updateIntervalGeneratorFactory,
+            deps: [UPDATE_INTERVAL_GENERATOR],
+          },
+          {
+            provide: TEST_SERVICE_2,
+            useFactory: updateIntervalGeneratorFactory,
+            deps: [UPDATE_INTERVAL_GENERATOR],
+          },
+        ],
+      });
+
+      updateIntervalGeneratorInstance = TestBed.inject(
+        UPDATE_INTERVAL_GENERATOR
+      );
+    });
+
+    it('should not be the original method', () => {
+      expect(TestBed.inject(UPDATE_INTERVAL_GENERATOR)).not.toBe(
+        defaultUpdateIntervalGenerator
+      );
+    });
+
+    it('should always return the same object', () => {
+      expect((TestBed.inject(TEST_SERVICE_1) as { generator }).generator).toBe(
+        updateIntervalGeneratorInstance
+      );
+      expect((TestBed.inject(TEST_SERVICE_2) as { generator }).generator).toBe(
+        updateIntervalGeneratorInstance
+      );
+    });
+
+    it('should call the custom provided method', () => {
+      const customInstance = TestBed.inject(UPDATE_INTERVAL_GENERATOR);
+
+      expect(customInstance(zeroTimeDiff)).toEqual(0);
+      expect(spyInstance).toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/ng-time-past-pipe/src/lib/time-past.module.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-past.module.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import { NgTimePastPipeModule } from './time-past.module';
+
+describe('NgTimePastPipeModule', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgTimePastPipeModule],
+    });
+  });
+
+  it('is being initialized', () => {
+    const module = TestBed.inject(NgTimePastPipeModule);
+
+    expect(module).toBeTruthy();
+  });
+});

--- a/projects/ng-time-past-pipe/src/lib/time-past.pipe.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-past.pipe.spec.ts
@@ -1,0 +1,150 @@
+import { NgTimePastPipePipe } from './time-past.pipe';
+import { ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { interval } from 'rxjs';
+import { defaultTimeDiffGenerator, TimeDiff } from './time-diff';
+import { defaultUpdateIntervalGenerator } from './time-interval';
+import * as timePast from './time-past';
+import * as timeDiff from './time-diff';
+
+describe('NgTimePastPipePipe', () => {
+  const changeDetectorRefSpy = jasmine.createSpyObj('changeDetectorRef', [
+    'markForCheck',
+    'detach',
+    'reattach',
+  ]);
+  const timeDiffGeneratorSpy = jasmine.createSpy(
+    'timeDiffGenerator',
+    defaultTimeDiffGenerator
+  );
+  const updateIntervalGeneratorSpy = jasmine.createSpy(
+    'updateIntervalGenerator',
+    defaultUpdateIntervalGenerator
+  );
+  let pipe: NgTimePastPipePipe;
+
+  beforeEach(() => {
+    pipe = new NgTimePastPipePipe(
+      changeDetectorRefSpy as ChangeDetectorRef,
+      interval(1000),
+      timeDiffGeneratorSpy,
+      updateIntervalGeneratorSpy
+    );
+  });
+
+  describe('@ngOnDestroy', () => {
+    let unsubscribeSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      unsubscribeSpy = spyOn(
+        (pipe as any).intervalSubscription,
+        'unsubscribe'
+      ).and.callThrough();
+    });
+
+    it('should close all subscriptions', () => {
+      pipe.ngOnDestroy();
+      expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('@transform', () => {
+    let validateTAInputTypeSpy: jasmine.Spy<(...args) => boolean>;
+    let parseInputValueSpy: jasmine.Spy<(...args) => number>;
+    let createTimeDiffSpy: jasmine.Spy<(...args) => TimeDiff>;
+
+    beforeAll(() => {
+      validateTAInputTypeSpy = spyOn(timePast, 'validateTAInputType');
+      parseInputValueSpy = spyOn(timePast, 'parseInputValue');
+      createTimeDiffSpy = spyOn(timeDiff, 'createTimeDiff');
+    });
+
+    beforeEach(() => {
+      validateTAInputTypeSpy.calls.reset();
+      parseInputValueSpy.calls.reset();
+      createTimeDiffSpy.calls.reset();
+      timeDiffGeneratorSpy.calls.reset();
+      updateIntervalGeneratorSpy.calls.reset();
+      changeDetectorRefSpy.detach.calls.reset();
+      changeDetectorRefSpy.reattach.calls.reset();
+
+      timeDiffGeneratorSpy.and.callThrough();
+      validateTAInputTypeSpy.and.returnValue(true);
+      parseInputValueSpy.and.callThrough();
+      createTimeDiffSpy.and.callThrough();
+    });
+
+    it('should call all corresponding module function', () => {
+      const input = new Date(Date.now() - 3600).toISOString();
+
+      expect(pipe.transform(input)).toBeDefined();
+      expect(validateTAInputTypeSpy).toHaveBeenCalledOnceWith(input);
+      expect(parseInputValueSpy).toHaveBeenCalledOnceWith(input);
+      expect(createTimeDiffSpy).toHaveBeenCalledOnceWith(
+        parseInputValueSpy.calls.first().returnValue
+      );
+      expect(timeDiffGeneratorSpy).toHaveBeenCalledOnceWith(
+        createTimeDiffSpy.calls.first().returnValue
+      );
+      expect(updateIntervalGeneratorSpy).toHaveBeenCalledOnceWith(
+        createTimeDiffSpy.calls.first().returnValue
+      );
+      expect(changeDetectorRefSpy.detach).toHaveBeenCalledTimes(1);
+      expect(changeDetectorRefSpy.detach).toHaveBeenCalledBefore(
+        changeDetectorRefSpy.reattach
+      );
+      expect(changeDetectorRefSpy.reattach).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('@isValidInput', () => {
+    let isValidInputSpy: jasmine.Spy;
+    let consoleSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      isValidInputSpy = spyOn(pipe as any, 'isValidInput').and.callThrough();
+      consoleSpy = spyOn(console, 'warn').and.callFake((m) => {});
+
+      isValidInputSpy.calls.reset();
+      consoleSpy.calls.reset();
+      timeDiffGeneratorSpy.and.callThrough();
+      updateIntervalGeneratorSpy.and.callThrough();
+    });
+
+    it('returns input when input validation fails', () => {
+      const input1 = false;
+      const input2 = null;
+
+      expect(pipe.transform(input1 as any)).toEqual(input1);
+
+      expect(pipe.transform(input1 as any)).toEqual(input1);
+      expect(pipe.transform(input2 as any)).toEqual(input2);
+
+      expect(isValidInputSpy.calls.all().map((call) => call.args[0])).toEqual([
+        input1,
+        input1,
+        input2,
+      ]);
+      expect(consoleSpy)
+        .withContext('Warn log should only be called one per input value')
+        .toHaveBeenCalledTimes(2);
+
+      // @ts-ignore
+      expect(pipe.lastInput).toEqual(input2);
+    });
+
+    it('returns string value when input is valid', () => {
+      const input = new Date().toISOString();
+
+      const result = pipe.transform(input);
+
+      expect(result).toBeDefined();
+      expect(result).not.toBe(input);
+
+      expect(isValidInputSpy).toHaveBeenCalledWith(input);
+      expect(consoleSpy).toHaveBeenCalledTimes(0);
+
+      // @ts-ignore
+      expect(pipe.lastInput).toEqual(input);
+    });
+  });
+});

--- a/projects/ng-time-past-pipe/src/lib/time-past.service.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-past.service.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from '@angular/core/testing';
+import { TimePastService } from './time-past.service';
+import {
+  defaultTimeDiffGenerator,
+  TIME_DIFF_GENERATOR,
+  TimeDiff,
+  TimeDiffGenerator,
+} from './time-diff';
+
+import * as timePast from './time-past';
+import * as timeDiff from './time-diff';
+
+describe('TimePastService injection', () => {
+  let service: TimePastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+
+    service = TestBed.inject(TimePastService);
+  });
+
+  it('can be created', () => {
+    expect(service).toBeDefined();
+  });
+});
+
+describe('@timePast', () => {
+  const generatorSpy = jasmine.createSpy(
+    'timeDiffGenerator',
+    defaultTimeDiffGenerator
+  );
+  let service: TimePastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TimePastService,
+        { provide: TIME_DIFF_GENERATOR, useValue: generatorSpy },
+      ],
+    });
+
+    service = TestBed.inject(TimePastService);
+
+    generatorSpy.and.stub();
+  });
+
+  describe('input validation', () => {
+    let timeDiffGeneratorSpy: jasmine.SpyObj<TimeDiffGenerator>;
+    let validateTAInputTypeSpy: jasmine.Spy<(...args) => boolean>;
+
+    beforeAll(() => {
+      validateTAInputTypeSpy = spyOn(timePast, 'validateTAInputType');
+      timeDiffGeneratorSpy = TestBed.inject(
+        TIME_DIFF_GENERATOR
+      ) as jasmine.SpyObj<TimeDiffGenerator>;
+    });
+
+    beforeEach(() => {
+      validateTAInputTypeSpy.calls.reset();
+      generatorSpy.and.callThrough();
+    });
+
+    it(`should return undefined when input validation fails`, () => {
+      validateTAInputTypeSpy.and.returnValue(false);
+
+      const input = new Date().toISOString();
+      expect(service.timePast(input)).toBeUndefined();
+      expect(validateTAInputTypeSpy).toHaveBeenCalledOnceWith(input);
+    });
+
+    it(`should not return undefined when input validation succeed`, () => {
+      validateTAInputTypeSpy.and.returnValue(true);
+
+      const input = new Date();
+      expect(service.timePast(input)).toBeDefined();
+      expect(validateTAInputTypeSpy).toHaveBeenCalledOnceWith(input);
+    });
+  });
+
+  describe('further modules called', () => {
+    let validateTAInputTypeSpy: jasmine.Spy<(...args) => boolean>;
+    let parseInputValueSpy: jasmine.Spy<(...args) => number>;
+    let createTimeDiffSpy: jasmine.Spy<(...args) => TimeDiff>;
+
+    beforeAll(() => {
+      validateTAInputTypeSpy = spyOn(timePast, 'validateTAInputType');
+      parseInputValueSpy = spyOn(timePast, 'parseInputValue');
+      createTimeDiffSpy = spyOn(timeDiff, 'createTimeDiff');
+    });
+
+    beforeEach(() => {
+      validateTAInputTypeSpy.calls.reset();
+      parseInputValueSpy.calls.reset();
+      createTimeDiffSpy.calls.reset();
+      generatorSpy.calls.reset();
+
+      generatorSpy.and.callThrough();
+      validateTAInputTypeSpy.and.returnValue(true);
+      parseInputValueSpy.and.callThrough();
+      createTimeDiffSpy.and.callThrough();
+    });
+
+    it('should call all corresponding module function', () => {
+      const input = new Date().toISOString();
+
+      expect(service.timePast(input)).toBeDefined();
+      expect(validateTAInputTypeSpy).toHaveBeenCalledOnceWith(input);
+      expect(parseInputValueSpy).toHaveBeenCalledOnceWith(input);
+      expect(createTimeDiffSpy).toHaveBeenCalledOnceWith(
+        parseInputValueSpy.calls.first().returnValue
+      );
+      expect(generatorSpy).toHaveBeenCalledOnceWith(
+        createTimeDiffSpy.calls.first().returnValue
+      );
+    });
+  });
+});

--- a/projects/ng-time-past-pipe/src/lib/time-past.spec.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-past.spec.ts
@@ -1,0 +1,84 @@
+import { parseInputValue, validateTAInputType } from './time-past';
+
+describe('parseInputValue', () => {
+  const time = Date.now();
+
+  beforeEach(() => {
+    jasmine.clock().mockDate(new Date(time));
+  });
+
+  describe('Time in the past', () => {
+    it('should pass-through positive numeric values that are smaller than unix timestamp (length 10)', () => {
+      expect(parseInputValue(5)).toBe(5);
+      expect(parseInputValue(999)).toBe(999);
+      expect(parseInputValue(123456789)).toBe(123456789);
+      expect(parseInputValue(987654321)).toBe(987654321);
+      expect(parseInputValue(639529)).toBe(639529);
+      expect(parseInputValue(0)).toBe(0);
+    });
+
+    it('should parse time in past from unix time for positive numeric values (length 10)', () => {
+      expect(parseInputValue(Math.floor(new Date(time - 5000).getTime() / 1000))).toBe(5);
+      expect(parseInputValue(Math.floor(new Date(time - 100000).getTime() / 1000))).toBe(100);
+      expect(parseInputValue(Math.floor(new Date(time - 3256000).getTime() / 1000))).toBe(3256);
+      expect(parseInputValue(Math.floor(new Date(time).getTime() / 1000))).toBe(0);
+    });
+
+    it('should parse time in past from date objects', () => {
+      expect(parseInputValue(new Date(time - 5000))).toBe(5);
+      expect(parseInputValue(new Date(time - 100000))).toBe(100);
+      expect(parseInputValue(new Date(time - 3256000))).toBe(3256);
+      expect(parseInputValue(new Date(time))).toBe(0);
+    });
+
+    it('should parse time in past from iso strings', () => {
+      expect(parseInputValue(new Date(time - 5000).toISOString())).toBe(5);
+      expect(parseInputValue(new Date(time - 100000).toISOString())).toBe(100);
+      expect(parseInputValue(new Date(time - 3256000).toISOString())).toBe(3256);
+      expect(parseInputValue(new Date(time).toISOString())).toBe(0);
+    });
+  });
+
+  describe('Time in the future', () => {
+    it('should pass-through negative numeric values', () => {
+      expect(parseInputValue(-500)).toBe(-500);
+      expect(parseInputValue(-1)).toBe(-1);
+      expect(parseInputValue(-999)).toBe(-999);
+      expect(parseInputValue(Number.MIN_SAFE_INTEGER)).toBe(Number.MIN_SAFE_INTEGER);
+    });
+
+    it('should parse time in future from unix time for positive numeric values (length 10)', () => {
+      expect(parseInputValue(Math.floor(new Date(time + 5000).getTime() / 1000))).toBe(-5);
+      expect(parseInputValue(Math.floor(new Date(time + 100000).getTime() / 1000))).toBe(-100);
+      expect(parseInputValue(Math.floor(new Date(time + 3256000).getTime() / 1000))).toBe(-3256);
+    });
+
+    it('should parse time in future from iso strings', () => {
+      expect(parseInputValue(new Date(time + 5000).toISOString())).toBe(-5);
+      expect(parseInputValue(new Date(time + 100000).toISOString())).toBe(-100);
+      expect(parseInputValue(new Date(time + 3256000).toISOString())).toBe(-3256);
+    });
+  });
+
+});
+
+describe('validateTAInputType', () => {
+  it('return true on valid inputs', () => {
+    expect(validateTAInputType('123')).toBeTrue();
+    expect(validateTAInputType(1)).toBeTrue();
+    expect(validateTAInputType(new Date())).toBeTrue();
+  });
+
+  it('return false on invalid inputs', () => {
+    // @ts-ignore
+    expect(validateTAInputType(() => true)).toBeFalse();
+    // @ts-ignore
+    expect(validateTAInputType(false)).toBeFalse();
+    // @ts-ignore
+    expect(validateTAInputType(null)).toBeFalse();
+    // @ts-ignore
+    expect(validateTAInputType(undefined)).toBeFalse();
+    // @ts-ignore
+    expect(validateTAInputType({})).toBeFalse();
+  });
+});

--- a/projects/ng-time-past-pipe/src/lib/time-past.ts
+++ b/projects/ng-time-past-pipe/src/lib/time-past.ts
@@ -13,7 +13,10 @@ export type TAInput = number | string | Date;
 export const parseInputValue = (value: TAInput): number => {
   let dateValueTime;
   if (typeof value === 'number') {
-    if (value < 0) { value *= -1; } // Negative number will be handled a positive
+    if (value <= 0) {
+      // Negative number will always be handled as seconds in the future
+      return value;
+    }
 
     const length = Math.ceil(Math.log10(value + 1));
     if (length < 10 && length > 0) {
@@ -27,13 +30,7 @@ export const parseInputValue = (value: TAInput): number => {
     dateValueTime = (value instanceof Date ? value : new Date(value)).getTime();
   }
 
-  const dateNowTime = Date.now();
-  if (dateNowTime <= dateValueTime) {
-    return -1; // Ceil future event
-  }
-
-  // Using Math.floor to make sure show the past seconds
-  return Math.floor((dateNowTime - dateValueTime) / 1000);
+  return Math.floor((Date.now() - dateValueTime) / 1000);
 };
 
 /**

--- a/projects/ng-time-past-pipe/tsconfig.spec.json
+++ b/projects/ng-time-past-pipe/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "CommonJS",
     "outDir": "../../out-tsc/spec",
     "types": ["jasmine", "node"]
   },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,7 +11,7 @@
     <div class="example-container" *ngFor="let example of outputExamples">
       <div class="example-header">
         <h3>{{ example.label }}</h3>
-        <span class="example--source">{{ example.source ? example.source : example.value }}</span>
+        <span class="example--source">{{ example.source ? example.source : (example.value | date: 'medium') }}</span>
       </div>
       <div class="example-wrapper">
         <div class="example--value">{{ example.value | timePast }}</div>
@@ -23,7 +23,7 @@
 <div class="panel">
 
   <h2 id="data-source-types">2. Data Source Types</h2>
-  <button type="button" class="btn btn-reset" title="Resets the examples to 'NOW()'" (click)="loadDataSourcesExamples()">Reset</button>
+  <button type="button" class="btn btn-reset" title="Resets the examples to its initial value" (click)="loadDataSourcesExamples()">Reset</button>
 
 
   <div class="panel--content">
@@ -43,13 +43,16 @@
 
 <div class="panel">
 
-  <h2 id="fallback-results">3. Fallback Results</h2>
+  <h2 id="future-results">3. Times in future</h2>
+  <button type="button" class="btn btn-reset" title="Resets the examples to its initial value" (click)="loadDataFutureExamples()">Reset</button>
 
   <div class="panel--content">
-    <div class="example-container" *ngFor="let example of fallbackExamples">
+    <p class="panel-description">Even dates in the future are supported.</p>
+
+    <div class="example-container" *ngFor="let example of futureExamples">
       <div class="example-header">
         <h3>{{ example.label }}</h3>
-        <span class="example--source">{{ example.source ? example.source : example.value }}</span>
+        <span class="example--source">{{ example.source ? example.source : (example.value | date: 'medium') }}</span>
       </div>
       <div class="example-wrapper">
         <div class="example--value">{{ example.value | timePast }}</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { getDataSourcesExamples, getFallbackExamples, getOutputExamples } from './examples';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { getDataSourcesExamples, getFutureExamples, getOutputExamples } from './examples';
 
 
 @Component({
@@ -12,15 +12,24 @@ export class AppComponent {
 
   outputExamples = getOutputExamples();
   sourcesExamples = getDataSourcesExamples();
-  fallbackExamples = getFallbackExamples();
+  futureExamples = getFutureExamples();
   customInputValue: any;
+
+  constructor(private readonly cdr: ChangeDetectorRef) {}
 
   loadDataOutputExamples(): void {
     this.outputExamples = getOutputExamples();
+    this.cdr.markForCheck();
   }
 
   loadDataSourcesExamples(): void {
     this.sourcesExamples = getDataSourcesExamples();
+    this.cdr.markForCheck();
+  }
+
+  loadDataFutureExamples(): void {
+    this.futureExamples = getFutureExamples();
+    this.cdr.detectChanges();
   }
 
   onCustomInputChange(event?): void {

--- a/src/app/examples.ts
+++ b/src/app/examples.ts
@@ -69,21 +69,65 @@ export function getDataSourcesExamples(): Example[] {
       value: (new Date()).toISOString(),
     },
     {
-      label: 'Numeric Value (milliseconds)',
+      label: 'Numeric Value (JS timestamp)',
       value: Date.now(),
     },
     {
-      label: 'Numeric Value (seconds)',
+      label: 'Numeric Value (Unix timestamp)',
       value: Math.floor(Date.now() / 1000),
+    },
+    {
+      label: 'Static numeric Value (seconds)',
+      value: 60,
     },
   ];
 }
 
-export function getFallbackExamples(): Example[] {
+export function getFutureExamples(): Example[] {
   return [
     {
-      label: 'Some time in the Future',
-      value: Math.floor(Date.now() / 1000) + 2676648,
+      label: 'Under 60 seconds in the future',
+      value: new Date(Date.now() + (45 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 90 seconds in the future',
+      value: new Date(Date.now() + (77 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 45 minutes in the future',
+      value: new Date(Date.now() + (23 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 90 minutes in the future',
+      value: new Date(Date.now() + (55 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 22 hours in the future',
+      value: new Date(Date.now() + (12 * 60 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 36 hours in the future',
+      value: new Date(Date.now() + (26 * 60 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 25 days in the future',
+      value: new Date(Date.now() + (18 * 24 * 60 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 45 days in the future',
+      value: new Date(Date.now() + (35 * 24 * 60 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 345 days in the future',
+      value: new Date(Date.now() + (212 * 24 * 60 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'Under 545 days in the future',
+      value: new Date(Date.now() + (416 * 24 * 60 * 60 * 1000)).toISOString(),
+    },
+    {
+      label: 'More than 545 days in the future',
+      value: new Date(Date.now() + (900 * 24 * 60 * 60 * 1000)).toISOString(),
     },
   ];
 }


### PR DESCRIPTION
Display both, past and future events well readable.

BREAKING CHANGE: The first parameter in `CUSTOM_TIME_DIFF_GENERATOR` (diff object) may now indicate a time in the future. Therefore
The first parameter in `CUSTOM_TIME_DIFF_GENERATOR` may now represent a future event. Those, could be mistaken as past events. To distinguish, please use the `isFuture` property.

Resolves: #6 